### PR TITLE
Don't set the value of the editor if the value is undefined

### DIFF
--- a/addon/components/pell-editor.js
+++ b/addon/components/pell-editor.js
@@ -31,8 +31,9 @@ export default Component.extend({
   },
 
   _setValue() {
-    if (this.get('pell').innerHTML !== this.get('value')) {
-      this.get('pell').innerHTML = this.get('value');
+    const val = this.get('value');
+    if (this.get('pell').innerHTML !== val && typeof val !== 'undefined') {
+      this.get('pell').innerHTML = val;
     }
   }
 });


### PR DESCRIPTION
Fixes #34 