### PR TITLE
Allow configurable content classes

### DIFF
--- a/addon/components/pell-editor.js
+++ b/addon/components/pell-editor.js
@@ -29,8 +29,7 @@ export default Component.extend({
   _options() {
     return Object.assign({}, this.get('pellOptions'), {
       element: this.element,
-      onChange: this.onChange,
-
+      onChange: this.onChange
     });
   },
 

--- a/addon/components/pell-editor.js
+++ b/addon/components/pell-editor.js
@@ -16,9 +16,12 @@ export default Component.extend({
   didInsertElement() {
     this._super(...arguments);
 
-    let pellInstance = pell.init(this._options());
+    const options = this._options();
+    const pellInstance = pell.init(options);
 
-    this.set('pell', pellInstance.querySelector(".pell-content"));
+    const contentClass = options.classes && options.classes.content || 'pell-content';
+    const contentClassSelector = `.${contentClass.split(' ').join('.')}`;
+    this.set('pell', pellInstance.querySelector(contentClassSelector));
 
     this._setValue();
   },
@@ -26,7 +29,8 @@ export default Component.extend({
   _options() {
     return Object.assign({}, this.get('pellOptions'), {
       element: this.element,
-      onChange: this.onChange
+      onChange: this.onChange,
+
     });
   },
 

--- a/tests/integration/components/pell-editor-test.js
+++ b/tests/integration/components/pell-editor-test.js
@@ -54,4 +54,15 @@ describe('Integration | Component | pell editor', function() {
       expect(this.get('value')).to.equal('Taadaa!');
     });
   });
+
+  it('respects custom content classes', function() {
+    this.set('value', 'Initial value');
+    this.set('pellOptions', {
+      classes: {
+        content: 'custom class',
+      }
+    });
+    this.render(hbs`{{pell-editor pellOptions=pellOptions value=value}}`);
+    expect($('.custom.class').html()).to.equal('Initial value');
+  });
 });


### PR DESCRIPTION
Pell allows custom content classes and providing those classes removes the defaults.

Here, inspect `pellOptions.classes.content` before defaulting to the `.pell-content` content selector.