### PR TITLE
Fix primitives output as text in pre-Chromium Edge

### DIFF
--- a/addon/components/pell-editor.js
+++ b/addon/components/pell-editor.js
@@ -36,7 +36,7 @@ export default Component.extend({
   _setValue() {
     const val = this.get('value');
     if (this.get('pell').innerHTML !== val && typeof val !== 'undefined') {
-      this.get('pell').innerHTML = val;
+      this.get('pell').innerHTML = val || '';
     }
   }
 });


### PR DESCRIPTION
In Edge 18, if values like "null" and "false" are passed, the editor's contents are set to the literal text "null" or "false" etc. This commit fixes that behavior for Edge, and should still behave the same way overall and in other browsers of wiping existing content when a falsy value gets passed to _setValue().