### PR TITLE
Let undefined values update state, add demonstration test

### DIFF
--- a/addon/components/pell-editor.js
+++ b/addon/components/pell-editor.js
@@ -35,8 +35,8 @@ export default Component.extend({
 
   _setValue() {
     const val = this.get('value');
-    if (this.get('pell').innerHTML !== val && typeof val !== 'undefined') {
-      this.get('pell').innerHTML = val;
+    if (this.get('pell').innerHTML !== val) {
+      this.get('pell').innerHTML = val === undefined ? null : val;
     }
   }
 });

--- a/tests/integration/components/pell-editor-test.js
+++ b/tests/integration/components/pell-editor-test.js
@@ -50,6 +50,13 @@ module('Integration | Component | pell editor', function(hooks) {
       document.querySelector('.pell-content').dispatchEvent(new Event('input'));
       assert.equal(this.value, 'Taadaa!');
     });
+
+    test('mutates state inside if value is set to undefined', async function(assert) {
+      this.set('value', 'new value');
+      assert.dom('.pell-content').hasText('new value');
+      this.set('value', undefined);
+      assert.dom('.pell-content').hasText('');
+    });
   });
 
   test('respects custom content classes', async function(assert) {


### PR DESCRIPTION
`undefined` values don't update the Pell editor state by design. This makes sense on initial render of the component.

However `ember-data` model attributes are `undefined` by default, so it becomes necessary to have to manually reset the `contenteditable` state each time the component gets an undefined value from, for example, a newly created record.